### PR TITLE
Bugfix/debug interface mode

### DIFF
--- a/source/daplink/interface/swd_host.h
+++ b/source/daplink/interface/swd_host.h
@@ -33,6 +33,7 @@ extern "C" {
 uint8_t swd_init(void);
 uint8_t swd_off(void);
 uint8_t swd_init_debug(void);
+uint8_t swd_uninit_debug(void);
 uint8_t swd_read_dp(uint8_t adr, uint32_t *val);
 uint8_t swd_write_dp(uint8_t adr, uint32_t val);
 uint8_t swd_read_ap(uint32_t adr, uint32_t *val);

--- a/source/daplink/interface/target_flash.c
+++ b/source/daplink/interface/target_flash.c
@@ -79,6 +79,7 @@ static error_t target_flash_uninit(void)
         target_set_state(RESET_RUN);
     }
 
+    swd_uninit_debug();
     swd_off();
     return ERROR_SUCCESS;
 }

--- a/source/target/nordic/target_reset_nrf5x_sam3u2c.c
+++ b/source/target/nordic/target_reset_nrf5x_sam3u2c.c
@@ -70,8 +70,11 @@ void swd_set_target_reset(uint8_t asserted)
                 swd_write_memory(0xE000ED0C, (uint8_t *)&swd_mem_write_data, 4);
                 //os_dly_wait(1);
             }
+            swd_uninit_debug();
         }
-        else {           
+        else {
+            swd_init_debug();
+            
             swd_read_ap(0x010000FC, &ap_index_return);
             if (ap_index_return == 0x02880000) {
                 // Device has CTRL-AP
@@ -80,7 +83,7 @@ void swd_set_target_reset(uint8_t asserted)
             else {
                 // No CTRL-AP - Soft reset has been performed
             }
-            PIOA->PIO_MDER = PIN_SWDIO | PIN_SWCLK | PIN_nRESET;
+            swd_uninit_debug();
         }
     }
     else {


### PR DESCRIPTION
Added swd_uninit_debug() because device was left in debug interface mode after debug session was done.
